### PR TITLE
fix: single failure scenario file paths

### DIFF
--- a/workflow/4a_losses/_losses.smk
+++ b/workflow/4a_losses/_losses.smk
@@ -53,7 +53,7 @@ def get_single_failure_scenario_file(wildcards):
         return []
     if row.sector == "buildings":
         return f"{DATA}/{sfs}"
-    return f"{wildcards.output_path}/{sfs}"
+    return f"{OUTPUT}/{sfs}"
 
 
 rule EAD_EAEL:


### PR DESCRIPTION
I think the sfs file path is `results/economic_losses` not `results/{hazard}_{threshold}/economic_losses`.