### PR TITLE
fix/EAD_EAEL_aggregation_naming_scheme

### DIFF
--- a/workflow/5_adaptation/_adaptation.smk
+++ b/workflow/5_adaptation/_adaptation.smk
@@ -143,7 +143,7 @@ timeseries_files = []
 for risk_type in ["EAD", "EAEL"]:
         timeseries_files = [
             *timeseries_files,
-            *[f"{risk_type}_timeseries_{val_type}" for val_type in ["amin", "mean", "amax"]]
+            *[f"{risk_type}_timeseries_{val_type}" for val_type in ["min", "mean", "max"]]
         ]
 rule damage_loss_timeseries_and_NPV:
     """

--- a/workflow/5_adaptation/damage_loss_timeseries_and_npv.py
+++ b/workflow/5_adaptation/damage_loss_timeseries_and_npv.py
@@ -258,7 +258,7 @@ def damage_loss_timeseries_and_npv(
 
     discounted_values = []
     for risk_type in ["EAD", "EAEL"]:
-        for val_type in ["amin", "mean", "amax"]:
+        for val_type in ["min", "mean", "max"]:
             if risk_type == "EAEL":
                 eael_exists = [
                     c


### PR DESCRIPTION
To successfully calculate adaptation option costs for road edges I required these changes.

N.B. User must also amend `processed_data/macroeconomic_data/gdp_growth_rates.xlsx` to use the min/max rather than amin/amax scheme. We will need to update the bundled `processed_data` archive.