### PR TITLE
Wireframe transport hotspots

### DIFF
--- a/workflow/4b_hotspots/_hotspots.smk
+++ b/workflow/4b_hotspots/_hotspots.smk
@@ -1,20 +1,26 @@
 """
 The rules in this file produce raster maps of 'hotspots' of infrastructure risk.
-These hotspots are computed from criticality analyses, where network assets are
-removed one-at-a-time and the network performance degradation measured.
 
-Maps are produced for each infrastructure sector.
+1) Define a raster hotspots grid
+2) Split assets on this grid
+2) Calculate the sum of asset value in each grid cell (exposure). This will
+    require looking up the cost column from the networks table and multiplying by
+    the appropriate exposure dimension, e.g. split length for edges.
+3) Perform a criticality assessment where all assets within a cell are failed
+    and calculate the resulting wider economic losses
+4) Sum results over asset classes for each sector
 """
 
 
 rule generate_hotspots_grid:
     """
     Create grid for hotspots analysis.
+
     Test with:
     snakemake -c1 results/hotspots/grid.tiff
     """
     input:
-        script = "scripts/hotspots/generate_grid.py",
+        script = "workflow/4b_hotspots/generate_grid.py",
         boundary = f"{DATA}/boundaries/jamaica.gpkg",
     params:
         cell_length = 1_000,
@@ -26,28 +32,101 @@ rule generate_hotspots_grid:
         python {input.script} {input.boundary} {params.cell_length} {params.boundary_buffer} {output.grid}
         """
 
-rule transport_hotspots:
+
+rule split_assets_by_hotspots_grid:
     """
-    Grid linestring economic losses to raster hotspots.
+    Split an asset class by the hotspots grid. This will split linestrings and
+    polygons on cell boundaries, creating new split rows for assets that span
+    more than one cell.
+
     Test with:
-    snakemake -c1 results/hotspots/transport.tiff
+    snakemake -c1 results/hotspots/splits/roads_splits__hazard_layers__edges.geoparquet
     """
     input:
-        script = "scripts/hotspots/rasterise_linestring_quantity.py",
-        road_and_rail_losses_geometry = f"{OUTPUT}/economic_losses/single_point_failure_road_rail_edges_economic_losses.gpkg",
-        grid = f"{OUTPUT}/hotspots/grid.tiff",
-    params:
-        variable_name = "economic_loss",
-        aggregation = "sum",
+        # hopefully this script can be made to work here without breaking changes
+        # if not, duplicate and adapt it
+        script = "workflow/1_damage/split_networks.py",
+        networks = config["paths"]["network_layers"],
+        hazards = "?",  # a CSV with header and one data row with path to hotspots grid -- see `workflow/hazard_layers.csv` for example
+        gpkg = lambda wildcards: f"{DATA}/{get_asset_metadata(wildcards).path}",
     output:
-        hotspots = f"{OUTPUT}/hotspots/transport.tiff",
+        splits = f"{OUTPUT}/hotspots/splits/{gpkg}_splits__hazard_layers__{layer}.geoparquet",
     shell:
         """
-        python \
-            {input.script} \
-            {input.road_and_rail_losses_geometry} \
-            {input.grid} \
-            {output.hotspots} \
-            {params.variable_name} \
-            {params.aggregation}
+        python {input.script} \
+            --network-csv {input.networks} \
+            --hazard-csv {input.hazards} \
+            --data-dir {DATA} \
+            --asset-gpkg {wildcards.gpkg} \
+            --asset-layer {wildcards.layer} \
+            --output-path {output.splits}
         """
+
+
+rule hotspots_exposure:
+    """
+    Calculate value of asset class within grid cell (multiply exposure
+    dimension by rebuild cost). Rebuild cost column names are available per
+    asset class in networks table under `asset_mean_cost_column`.
+
+    Test with:
+    snakemake -c1 results/hotspots/exposure/roads_edges_exposed_value.tiff
+    """
+    input:
+        script = "workflow/4b_hotspots/exposure.py",
+        networks = config["paths"]["network_layers"],
+        splits = f"{OUTPUT}/hotspots/splits/{gpkg}_splits__hazard_layers__{layer}.geoparquet",
+    output:
+        exposure = f"{OUTPUT}/hotspots/exposure/{gpkg}__{layer}.geoparquet",
+    shell:
+        """
+        python {input.script} \
+            --splits {input.splits} \
+            --network-csv {input.networks} \
+            --exposure {output.exposure}
+        """
+
+
+rule economic_loss_transport_hotspots_per_cell:
+    """
+    Find economic losses associated with the loss of road and rail edges
+
+    Test with:
+    snakemake -c1 results/hotspots/transport/cell/0.tiff
+    """
+    input:
+        script = "?",  # an adapted version of `workflow/3_criticality/single_link_failure.py`
+        airport_areas = f"{OUTPUT}/hotspots/splits/airport_polygon_splits__hazard_layers_areas.geoparquet",
+        port_areas = f"{OUTPUT}/hotspots/splits/port_polygon_splits__hazard_layers_areas.geoparquet",
+        road_edges = f"{OUTPUT}/hotspots/splits/rail_edges_splits__hazard_layers__edges.geoparquet",
+        rail_edges = f"{OUTPUT}/hotspots/splits/roads_edges_splits__hazard_layers__edges.geoparquet",
+        flow_data_dir = f"{OUTPUT}/transport_failures/nominal",
+    output:
+        per_cell_loss = f"{OUTPUT}/hotspots/transport/cell/{cell_id}.tiff",
+    shell:
+        """
+        python {input.script} \
+            --airport-splits {input.airport_areas} \
+            --port-splits {input.port_areas} \
+            --road-splits {input.road_edges} \
+            --rail-splits {input.rail_edges} \
+            --flow-data-dir {input.flow_data_dir} \
+            --cell-id {wildcards.cell_id} \
+            --output {output.per_cell_loss}
+        """
+
+
+rule economic_loss_transport_hotspots:
+    """
+    Output per-cell economic loss hotspots results as single raster.
+    """
+    input:
+        script = "?",
+        cells = "?",  # expand call over f"{OUTPUT}/hotspots/transport/cell/{cell_id}.tiff", for all cell_id in grid
+    output:
+        economic_loss = f"{OUTPUT}/hotspots/transport/economic_loss.tiff",
+    shell:
+        """
+        ?
+        """
+

--- a/workflow/4b_hotspots/generate_grid.py
+++ b/workflow/4b_hotspots/generate_grid.py
@@ -1,0 +1,104 @@
+"""
+Create a raster grid encompassing a given boundary and write to disk (tiff) with
+integer IDs as pixel values.
+"""
+
+
+from pathlib import Path
+import sys
+
+import geopandas as gpd
+import numpy as np
+import rasterio
+import rasterio.crs
+
+
+def harmonise_grid(
+    minimum: float, maximum: float, cell_length: float
+) -> tuple[int, float, float]:
+    """
+    Grow grid dimensions to encompass whole number of `cell_length`
+
+    Args:
+        minimum: Minimum dimension value
+        maximum: Maximum dimension value
+        cell_length: Length of cell side
+
+    Returns:
+        Number of cells
+        Adjusted minimum
+        Adjusted maximum
+    """
+    assert maximum > minimum
+
+    span: float = maximum - minimum
+    n_cells: int = int(np.ceil(span / cell_length))
+    delta: float = n_cells * cell_length - span
+    buffer: float = delta / 2
+
+    return n_cells, minimum - buffer, maximum + buffer
+
+
+def create_grid(
+    boundary_path: Path,
+    cell_length: float,
+    boundary_buffer: float,
+    output_grid: Path,
+) -> None:
+    """
+    Given a 2D boundary, generate a raster grid encompassing the provided
+    boundary and write to disk as GeoTIFF.
+
+    Args:
+        boundary_path: Path to geospatial file containing single geometry. The
+            output grid will be the bounding box of this geometry.
+        cell_length: Length of each output grid cell side. In units of boundary CRS.
+        boundary_buffer: Distance to buffer the boundary geometry by. In units of boundary CRS.
+        output_grid: Path to write the created grid to as GeoTIFF.
+    """
+
+    assert cell_length > 0
+    assert boundary_buffer > 0
+
+    boundary: gpd.GeoDataFrame = gpd.read_file(boundary_path)
+    bounding_geometry, = boundary.loc[:, "geometry"]
+
+    minx, miny, maxx, maxy = bounding_geometry.bounds
+    minx -= boundary_buffer
+    miny -= boundary_buffer
+    maxx += boundary_buffer
+    maxy += boundary_buffer
+
+    # determine grid bounding box to fit an integer number of grid cells in each dimension
+    i, minx, maxx = harmonise_grid(minx, maxx, cell_length)
+    j, miny, maxy = harmonise_grid(miny, maxy, cell_length)
+
+    # export grid_ids as .tiff file
+    with rasterio.open(
+        output_grid,
+        "w",
+        driver="GTiff",
+        height=j,
+        width=i,
+        count=1,
+        dtype="int32",
+        crs=boundary.crs,
+        transform=rasterio.Affine(cell_length, 0, minx, 0, cell_length, miny)
+    ) as dataset:
+        dataset.write(np.zeros((j, i)), 1)
+
+
+if __name__ == "__main__":
+    try:
+        boundary_path = Path(sys.argv[1])
+        cell_length = float(sys.argv[2])
+        buffer = float(sys.argv[3])
+        output_grid = Path(sys.argv[4])
+    except IndexError:
+        print(
+            "Usage: \npython generate_grid.py <input_boundary_path> <cell_length> <boundary_buffer> <output_grid_path>\n"
+            "Note that <cell_length> and <boundary_buffer> must be in units of the boundary CRS."
+        )
+        sys.exit()
+
+    create_grid(boundary_path, cell_length, buffer, output_grid)


### PR DESCRIPTION
Wireframe rules to:
1) Define a raster hotspots grid
2) Split assets on this grid
2) Calculate the sum of asset value in each grid cell (exposure). This will require looking up the cost column from the networks table and multiplying by the appropriate exposure dimension, e.g. split length for edges.
3) Perform a criticality assessment where all assets within a cell are failed and calculate the resulting wider economic losses
