### PR TITLE
fix: Road network asset_type tagging

### DIFF
--- a/config.json
+++ b/config.json
@@ -25,6 +25,16 @@
             "tertiary": "CLASS C",
             "residential": "RESIDENTIAL",
             "unclassified": "UNCLASSIFIED"
+        },
+        "OSM_to_damage_curve": {
+            "bridge": "road_bridge",
+            "motorway": "road_paved",
+            "trunk": "road_paved",
+            "primary": "road_paved",
+            "secondary": "road_paved",
+            "tertiary": "road_paved",
+            "residential": "road_paved",
+            "unclassified": "road_unpaved"
         }
     },
     "damages": {

--- a/workflow/2a_transport/_transport.smk
+++ b/workflow/2a_transport/_transport.smk
@@ -21,11 +21,10 @@ rule preprocess_road_network:
         - Project to EPSG 3448
         - Explode multilinestrings
         - Calculate edge lengths
+        - Assign asset_type for damage curve lookup
+        - Estimate NWA road classification from OSM tag_highway
         - Gap-fill speed limit data
         - Add topology and component labels
-
-        TODO: Add government road categorisation data (could spatial join
-        against NWA as Raghav did in scripts/preprocess/updated_road_network.py)
         """
 
         import logging
@@ -70,7 +69,10 @@ rule preprocess_road_network:
         edges.lanes = edges.lanes.astype(int)
         edges[edges.lanes == 0] = 1
 
-        logging.info("Infer NWA road classification from mapping")
+        logging.info("Set asset_type (for damage curve lookup)")
+        edges["asset_type"] = edges.tag_highway.map(config["road_classification"]["OSM_to_damage_curve"])
+
+        logging.info("Guess at NWA road classification from supplied mapping")
         edges["road_class"] = edges.tag_highway.map(config["road_classification"]["OSM_to_NWA"]) \
             .fillna(config["road_classification"]["default_NWA"])
 
@@ -109,7 +111,7 @@ rule preprocess_road_network:
         # the downstream workflow is written assuming that bridges are nodes
         # we take the from_node of the OSM bridge edge to be the bridge node
         # this is not central to the span, but to one side of it
-        bridge_edges = network.edges[network.edges.asset_type=="road_bridge"]
+        bridge_edges = network.edges[network.edges.bridge]
         bridge_edges_to_merge = bridge_edges.loc[
             :,
             ["from_id", "length_m", "min_damage_cost", "mean_damage_cost", "max_damage_cost", "cost_unit"]

--- a/workflow/2a_transport/_transport.smk
+++ b/workflow/2a_transport/_transport.smk
@@ -156,7 +156,11 @@ rule create_multi_modal_network:
     shell:
         f"""
         python {{input.script}} \
-            --processed-data-dir {DATA}
+            --road-network-path {{input.road}} \
+            --rail-network-path {{input.rail}} \
+            --port-path {{input.ports}} \
+            --airport-path {{input.airports}} \
+            --output-path {{output.multi_modal_network}}
         """
 
 

--- a/workflow/2a_transport/labour_to_work_flow_mapping.py
+++ b/workflow/2a_transport/labour_to_work_flow_mapping.py
@@ -72,12 +72,6 @@ def commuter_flow_mapping(network_file, buildings_file, population_file, out_dir
     ]
     network = edges[(edges["from_mode"] == "road") & (edges["to_mode"] == "road")][columns]
 
-    # 0.6 - 2.1% of the value per day
-    # so we need to make an assumption on the average wage per working person,
-    # say 200 USD per day. Then if a road is disrupted which has 1000 daily trips and
-    # they have to be rerouted with an hour, the cost would be: 0.4 * 200 * 1/24 * 100 = 333 USD
-    # So corrected for inflation in 2019 values, this would be 1.2-2.9 USD per hour of value of time for business related trips
-
     logging.info("Build network graph")
     graph = ig.Graph.TupleList(network.itertuples(index=False), edge_attrs=list(network.columns)[2:])
 

--- a/workflow/2a_transport/multi_modal_network_creation.py
+++ b/workflow/2a_transport/multi_modal_network_creation.py
@@ -2,7 +2,7 @@
 Connect ports, airports, railways and roads together into a multi-modal transport network.
 """
 
-import os
+import logging
 
 import click
 import pandas as pd
@@ -21,54 +21,60 @@ epsg_jamaica = 3448
 @click.command()
 @click.version_option("1.0.0")
 @click.option(
-    "--processed-data-dir",
-    "-p",
-    required=True,
-    type=click.Path(dir_okay=True, file_okay=False, exists=True),
-    help="Designated processed data directory.",
+    "--road-network-path", "-r", required=True,
+    type=click.Path(dir_okay=False, file_okay=True, exists=True),
+    help="Path to road network geopackage.",
 )
-def main(config):
-    processed_data_dir = config["paths"]["data"]
+@click.option(
+    "--rail-network-path", "-l", required=True,
+    type=click.Path(dir_okay=False, file_okay=True, exists=True),
+    help="Path to rail network geopackage.",
+)
+@click.option(
+    "--port-path", "-p", required=True,
+    type=click.Path(dir_okay=False, file_okay=True, exists=True),
+    help="Path to ports geopackage.",
+)
+@click.option(
+    "--airport-path", "-a", required=True,
+    type=click.Path(dir_okay=False, file_okay=True, exists=True),
+    help="Path to airports geopackage.",
+)
+@click.option(
+    "--output-path", "-o", required=True,
+    type=click.Path(dir_okay=False, file_okay=True, exists=False),
+    help="Path to write multi-modal network geopackage.",
+)
+def main(
+    road_network_path: str,
+    rail_network_path: str,
+    port_path: str,
+    airport_path: str,
+    output_path: str
+):
 
-    airports = gpd.read_file(
-        os.path.join(
-            processed_data_dir, "networks", "transport", "airport_polygon.gpkg"
-        ),
-        layer="areas",
-    )
+    airports = gpd.read_file(airport_path, layer="areas")
     airports = airports[airports["asset_type"] == "terminal"]
     airports = polygon_to_points(airports)
     airports["mode"] = "air"
 
-    ports = gpd.read_file(
-        os.path.join(processed_data_dir, "networks", "transport", "port_polygon.gpkg"),
-        layer="areas",
-    )
+    ports = gpd.read_file(port_path, layer="areas")
     ports = polygon_to_points(ports)
     ports["mode"] = "port"
 
-    rail_nodes = gpd.read_file(
-        os.path.join(processed_data_dir, "networks", "transport", "rail.gpkg"),
-        layer="nodes",
-    )
-    # rail_nodes.loc[rail_nodes["node_id"]=="railn_124","asset_type"] = "station"
-    # rail_nodes.loc[rail_nodes["node_id"]=="railn_44","status"] = "Functional"
+    rail_nodes = gpd.read_file(rail_network_path, layer="nodes")
     rail_nodes = rail_nodes[
         (rail_nodes["asset_type"] == "station") & (rail_nodes["status"] == "Functional")
     ]
     rail_nodes = rail_nodes.to_crs(epsg=epsg_jamaica)
     rail_nodes["mode"] = "rail"
 
-    road_nodes = gpd.read_file(
-        os.path.join(processed_data_dir, "networks", "transport", "roads.gpkg"),
-        layer="nodes",
-    )
+    road_nodes = gpd.read_file(road_network_path, layer="nodes")
     road_nodes = road_nodes[road_nodes["component_id"] == 1]
     road_nodes = road_nodes.to_crs(epsg=epsg_jamaica)
     road_nodes["mode"] = "road"
 
-    """Creating linkages
-    """
+    # create linkages
     multi_modal = []
     multi_modal.append(
         map_nearest_locations_and_create_lines(
@@ -91,9 +97,7 @@ def main(config):
         )
     )
 
-    """Add road and rail
-    """
-
+    # road and rail
     multi_modal = gpd.GeoDataFrame(
         pd.concat(multi_modal, axis=0, ignore_index=True),
         geometry="geometry",
@@ -105,34 +109,22 @@ def main(config):
     )
     multi_modal["speed"] = 40.0
     multi_modal["time"] = 0.001 * multi_modal["length_m"] / multi_modal["speed"]
-    print(multi_modal)
 
-    rail_edges = gpd.read_file(
-        os.path.join(processed_data_dir, "networks", "transport", "rail.gpkg"),
-        layer="edges",
-    )
+    rail_edges = gpd.read_file(rail_network_path, layer="edges")
     rail_edges = rail_edges[rail_edges["status"] == "Functional"]
     rail_edges["from_mode"] = "rail"
     rail_edges["to_mode"] = "rail"
     rail_edges["time"] = 0.001 * rail_edges["length_m"] / rail_edges["speed"]
 
-    road_edges = gpd.read_file(
-        os.path.join(processed_data_dir, "networks", "transport", "roads.gpkg"),
-        layer="edges",
-    )
-    road_edges_max_id = max(
-        [int(c.split("_")[1]) for c in road_edges["edge_id"].values.tolist()]
-    )
+    road_edges = gpd.read_file(road_network_path, layer="edges")
     road_edges = road_edges[road_edges["component_id"] == 1]
     road_edges["from_mode"] = "road"
     road_edges["to_mode"] = "road"
-    """Add road to fix lack of connectivity
-    """
 
     road_edges["time"] = 0.001 * road_edges["length_m"] / road_edges["speed_kph"]
     road_edges = road_edges.rename(columns={"speed_kph": "speed"})
-    print(rail_edges)
-    print(road_edges)
+
+    logging.info(f"Writing multi-modal network to disk: {output_path}")
     columns = [
         "from_node",
         "to_node",
@@ -157,14 +149,8 @@ def main(config):
         geometry="geometry",
         crs=f"EPSG:{epsg_jamaica}",
     )
-    print(multi_modal)
-    multi_modal.to_file(
-        os.path.join(
-            processed_data_dir, "networks", "transport", "multi_modal_network.gpkg"
-        ),
-        layer="edges",
-        driver="GPKG",
-    )
+    multi_modal.to_file(output_path, layer="edges", driver="GPKG")
+
     columns = ["node_id", "mode", "geometry"]
     multi_modal = gpd.GeoDataFrame(
         pd.concat(
@@ -180,15 +166,9 @@ def main(config):
         geometry="geometry",
         crs=f"EPSG:{epsg_jamaica}",
     )
-    print(multi_modal)
-    multi_modal.to_file(
-        os.path.join(
-            processed_data_dir, "networks", "transport", "multi_modal_network.gpkg"
-        ),
-        layer="nodes",
-        driver="GPKG",
-    )
+    multi_modal.to_file(output_path, layer="nodes", driver="GPKG")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
     main()


### PR DESCRIPTION
I had incorrect `asset_type` categorical strings for damage curve lookup -- most road edge assets were being ignored.

Also factored out some paths from `multi_modal_network_creation.py`