### PR TITLE
Set nodata value for non-positive values

### DIFF
--- a/workflow/4b_hotspots/_hotspots.smk
+++ b/workflow/4b_hotspots/_hotspots.smk
@@ -228,19 +228,21 @@ rule economic_loss_transport_hotspots:
         with rasterio.open(input.grid) as grid_dataset:
             arr: np.ndarray[float] = grid_dataset.read()[0].astype(np.float32)
 
+        no_data_value = np.nan
         write_kwargs = {
             "driver": "GTiff",
             "height": arr.shape[0],
             "width": arr.shape[1],
             "count": 1,
             "dtype": rasterio.float32,
+            "nodata": no_data_value,
             "crs": grid_dataset.crs,
             "transform": grid_dataset.transform
         }
 
         for variable in ("economic_loss", "isolation_loss", "rerouting_loss"):
             with rasterio.open(output[variable], "w", **write_kwargs) as output_dataset:
-                arr[loss.cell_index_y, loss.cell_index_x] = loss[variable]
+                arr[loss.cell_index_y, loss.cell_index_x] = np.where(loss[variable] > 0, loss[variable], no_data_value)
                 output_dataset.write(arr, 1)
 
 
@@ -249,7 +251,7 @@ rule economic_loss_transport_hotspots_gaussian_kernel:
     Apply quantity preserving smoothing Gaussian kernel to hotspots quantities.
 
     Test with:
-    snakemake -c1 results/hotspots/transport/economic_loss_smoothed.tiff",
+    snakemake -c1 results/hotspots/transport/economic_loss_smoothed.tiff,
     """
     input:
         script = "workflow/4b_hotspots/kde.py",

--- a/workflow/4b_hotspots/exposure.py
+++ b/workflow/4b_hotspots/exposure.py
@@ -2,8 +2,9 @@ import logging
 
 import click
 import geopandas as gpd
-import rioxarray
+import numpy as np
 import pandas as pd
+import rioxarray
 
 from jamaica_infrastructure.utils import is_sole_value
 
@@ -70,6 +71,10 @@ def exposure(network_csv: str, splits_path: str, grid_path: str, asset_gpkg: str
 
     exposure = exposure.reset_index()
 
+    # set np.nan for non-positive values, store as nodata in raster
+    no_data_value = np.nan
+    exposure.loc[exposure["split_rehab_cost_J$"] <= 0, "split_rehab_cost_J$"] = no_data_value
+
     logging.info("Reading raster grid")
     # use the hotspots grid as a template -- inherit the transform for output
     grid = rioxarray.open_rasterio(grid_path).astype(float)  # promote to float
@@ -81,6 +86,7 @@ def exposure(network_csv: str, splits_path: str, grid_path: str, asset_gpkg: str
         }
     ] = exposure["split_rehab_cost_J$"]
     grid.name = f"{asset_gpkg}_{asset_layer}_rehab_cost_J$"
+    grid = grid.rio.write_nodata(no_data_value)
 
     logging.info(f"Exposure:\n{grid}")
 

--- a/workflow/4b_hotspots/kde.py
+++ b/workflow/4b_hotspots/kde.py
@@ -4,6 +4,7 @@ import click
 import numpy as np
 import rasterio
 from rasterio.transform import from_origin
+import tqdm
 
 
 def gaussian_kernel(shape: tuple[int, int], center: tuple[int, int], bandwidth: float, target_integral: float):
@@ -71,7 +72,7 @@ def main(
     output_data = np.zeros((height, width), dtype=np.float32)
 
     logging.info("Adding Gaussian kernels")
-    for input_row in range(input_shape[0]):
+    for input_row in tqdm.tqdm(range(input_shape[0])):
         for input_col in range(input_shape[1]):
 
             loss = input_data[input_row, input_col]
@@ -93,7 +94,7 @@ def main(
             output_data += gaussian_kernel((height, width), center, bw_pixels, loss)
 
     logging.info("Asserting input and output raster sums are equal")
-    assert np.isclose(input_data.sum(), output_data.sum(), rtol=1E-3, atol=1)
+    assert np.isclose(np.nansum(input_data), np.nansum(output_data), rtol=1E-3, atol=1)
 
     logging.info(f"Write out to {output_raster_path}")
     write_kwargs = {


### PR DESCRIPTION
Set nodata value to `NaN` for non-positive values in transport hotspots maps.

Note that the economic loss hotspots rasters for the transport sector to be displayed in the phase 3 J-SRAT update have _positive_ valued thresholds, below which everything is set as nodata. This helps with visualisation as the raster nodata is rendered transparent. Another solution might be to clip the raster to the coastline, although this will mean losing quite a lot of the quantity where loss blooms near the coast (e.g. ports).