### PR TITLE
Assume single carriageway when missing data

### DIFF
--- a/workflow/2a_transport/_transport.smk
+++ b/workflow/2a_transport/_transport.smk
@@ -78,8 +78,11 @@ rule preprocess_road_network:
             edges.loc[(edges.tag_highway == road_class) & edges.tag_maxspeed.isna(), "speed_kph"] = modal_limit_kph
 
         logging.info("Gap-filling # lanes")
-        edges.lanes = edges.lanes.astype(int)
-        edges[edges.lanes == 0] = 1
+        edges.loc[edges.lanes == 0, "lanes"] = 1
+        # Set lanes to 2 (single carriageway) where OSM was missing data
+        # This matches the approach in the CCRI phase
+        edges.loc[edges.tag_lanes.isna(), "lanes"] = 2
+        edges.lanes = edges.lanes.astype(float)
 
         logging.info("Set asset_type (for damage curve lookup)")
         edges["asset_type"] = edges.tag_highway.map(config["road_classification"]["OSM_to_damage_curve"])


### PR DESCRIPTION
Previously, I had assumed that an edge without lane information should have lanes set to 1, i.e. labelled as single track. This PR changes that assumption to 2 lanes (single carriageway) as per the original CCRI road transport network.