### PR TITLE
Parse existing building sector codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,18 +6,33 @@ build-backend = "setuptools.build_meta"
 name = "jamaica-infrastructure"
 version = "0.0.1"
 authors = [
-  {name="Raghav Pant", email="raghav.pant@ouce.ox.ac.uk"},
-  {name="Tom Russell", email="tom.russell@ouce.ox.ac.uk"},
-  {name="Fred Thomas", email="fred.thomas@eci.ox.ac.uk"}
+  { name = "Raghav Pant", email = "raghav.pant@ouce.ox.ac.uk" },
+  { name = "Tom Russell", email = "tom.russell@ouce.ox.ac.uk" },
+  { name = "Fred Thomas", email = "fred.thomas@eci.ox.ac.uk" }
 ]
 description = "Helper package for jamaica-infrastructure workflow"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
 ]
+dependencies = [
+  "pandas",
+  "numpy",
+  "rasterio",
+  "xarray",
+  "rioxarray",
+  "geopandas",
+  "igraph",
+  "scipy",
+  "shapely",
+  "tqdm",
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
 
 [project.urls]
 "Homepage" = "https://github.com/nismod/jamaica-infrastructure"

--- a/src/jamaica_infrastructure/tests/test_utils.py
+++ b/src/jamaica_infrastructure/tests/test_utils.py
@@ -80,3 +80,10 @@ class TestParseJIC2005:
             "012",
         )
         assert parse_jic2005(code) == expected
+
+        code = "012-1"
+        expected = (
+            "011",
+            "012",
+        )
+        assert parse_jic2005(code) == expected

--- a/src/jamaica_infrastructure/tests/test_utils.py
+++ b/src/jamaica_infrastructure/tests/test_utils.py
@@ -1,10 +1,14 @@
 import numpy as np
 import pandas as pd
 
-from jamaica_infrastructure.utils import numeric_only_dataframe, is_sole_value
+from jamaica_infrastructure.utils import (
+    numeric_only_dataframe,
+    is_sole_value,
+    parse_jic2005,
+)
 
 
-class Test_numeric_only_dataframe:
+class TestNumericOnlyDataframe:
     def test_numeric_only_dataframe(self):
         df = pd.DataFrame({"a": [-0, 2, 3], "b": [4, 5, 6], "c": [1.2, 3.4, np.nan]})
         assert numeric_only_dataframe(df)
@@ -16,7 +20,7 @@ class Test_numeric_only_dataframe:
         assert not numeric_only_dataframe(df)
 
 
-class Test_is_sole_value:
+class TestIsSoleValue:
     def test_is_sole_value(self):
         assert is_sole_value(pd.Series([1, 1, 1]), 1)
         assert is_sole_value(pd.Series(["a", "a"]), "a")
@@ -31,3 +35,48 @@ class Test_is_sole_value:
         assert not is_sole_value(pd.Series([np.nan, np.nan]), 1)
         assert not is_sole_value(pd.Series([np.nan, "a", 1]), "a")
         assert not is_sole_value(pd.Series([np.nan, "a", 1]), np.nan)
+
+
+class TestParseJIC2005:
+    def test_special_cases(self):
+        code = "500-2/3"
+        expected = "50", "502", "503"
+        assert parse_jic2005(code) == expected
+
+        code = "401/410"
+        expected = "401", "41"
+        assert parse_jic2005(code) == expected
+
+        code = "132.0"
+        expected = ("132",)
+        assert parse_jic2005(code) == expected
+
+        code = "RES"
+        expected = ()
+        assert parse_jic2005(code) == expected
+
+    def test_length_two_codes_should_have_zero_prefix(self):
+        code = "20"
+        expected = ("020",)
+        assert parse_jic2005(code) == expected
+
+    def test_zero_terminated_codes_should_be_two_digit(self):
+        code = "650"
+        expected = ("65",)
+        assert parse_jic2005(code) == expected
+
+    def test_six_digit_codes_should_be_split(self):
+        code = "180190"
+        expected = (
+            "18",
+            "19",
+        )
+        assert parse_jic2005(code) == expected
+
+    def test_hyphenate_codes_indicate_a_range(self):
+        code = "011-2"
+        expected = (
+            "011",
+            "012",
+        )
+        assert parse_jic2005(code) == expected

--- a/src/jamaica_infrastructure/utils.py
+++ b/src/jamaica_infrastructure/utils.py
@@ -25,9 +25,76 @@ def get_asset(network_csv_path: str, asset_gpkg: str, asset_layer: str) -> pd.Se
     Get the path of an asset by its gpkg and layer strings.
     """
     df = pd.read_csv(network_csv_path)
-    row = df[(df['asset_gpkg'] == asset_gpkg) & (df['asset_layer'] == asset_layer)]
+    row = df[(df["asset_gpkg"] == asset_gpkg) & (df["asset_layer"] == asset_layer)]
     if len(row) == 0:
-        raise ValueError(f"No asset found for gpkg={asset_gpkg} and layer={asset_layer}")
+        raise ValueError(
+            f"No asset found for gpkg={asset_gpkg} and layer={asset_layer}"
+        )
     elif len(row) > 1:
-        raise ValueError(f"Multiple assets found for gpkg={asset_gpkg} and layer={asset_layer}")
+        raise ValueError(
+            f"Multiple assets found for gpkg={asset_gpkg} and layer={asset_layer}"
+        )
     return row.squeeze()
+
+
+def parse_jic2005(c: str) -> tuple[str]:
+    """Parse existing subsector codes to standard JIC 2005 two- or three-digit codes"""
+
+    # special case 1
+    if c == "500-2/3":
+        return "50", "502", "503"
+
+    # special case 2
+    if c == "401/410":
+        return "401", "41"
+
+    # special case 3
+    if c == "132.0":
+        return ("132",)
+
+    if c == "RES":
+        return ()
+
+    if c == "":
+        return ()
+
+    # length-two codes should have zero prefix (i.e. 20 means 020)
+    if len(c) == 2:
+        return (f"0{c}",)
+
+    # zero-terminated codes should be two-digit (i.e. 650 means 65)
+    if len(c) == 3:
+        if c[2] == "0":
+            return (c[:2],)
+        else:
+            return (c,)
+
+    # six-digit codes should be split (i.e. 180190 means 180, 190 => 18, 19)
+    if len(c) == 6:
+        codes = []
+        for code in parse_jic2005(c[:3]):
+            codes.append(code)
+        for code in parse_jic2005(c[3:]):
+            codes.append(code)
+        return tuple(codes)
+
+    # hyphenate codes indicate a range (i.e. 011-2 means 011, 012)
+    if "-" in c and "/" not in c:
+        start, end_digit = c.split("-")
+        if end_digit == start[-1]:
+            return parse_jic2005(start)
+        else:
+            cs = []
+            for c in parse_jic2005(start):
+                cs.append(c)
+            prefix = start[:2]
+            suffix_int = int(start[2])
+            end_int = int(end_digit)
+            while True:
+                suffix_int = suffix_int + 1
+                cs.append(f"{prefix}{suffix_int}")
+                if suffix_int == end_int:
+                    break
+            return tuple(cs)
+
+    raise ValueError(f"Unhandled JIC 2005 subsector code '{c}'")

--- a/src/jamaica_infrastructure/utils.py
+++ b/src/jamaica_infrastructure/utils.py
@@ -81,20 +81,27 @@ def parse_jic2005(c: str) -> tuple[str]:
     # hyphenate codes indicate a range (i.e. 011-2 means 011, 012)
     if "-" in c and "/" not in c:
         start, end_digit = c.split("-")
-        if end_digit == start[-1]:
+        prefix = start[:2]
+        suffix_int = int(start[2])
+        end_int = int(end_digit)
+
+        if end_int == suffix_int:
             return parse_jic2005(start)
-        else:
-            cs = []
-            for c in parse_jic2005(start):
-                cs.append(c)
-            prefix = start[:2]
-            suffix_int = int(start[2])
-            end_int = int(end_digit)
-            while True:
-                suffix_int = suffix_int + 1
-                cs.append(f"{prefix}{suffix_int}")
-                if suffix_int == end_int:
-                    break
-            return tuple(cs)
+
+        if end_int < suffix_int:
+            start = f"{prefix}{end_int}"
+            tmp = suffix_int
+            suffix_int = end_int
+            end_int = tmp
+
+        cs = []
+        for c in parse_jic2005(start):
+            cs.append(c)
+        while True:
+            suffix_int = suffix_int + 1
+            cs.append(f"{prefix}{suffix_int}")
+            if suffix_int == end_int:
+                break
+        return tuple(cs)
 
     raise ValueError(f"Unhandled JIC 2005 subsector code '{c}'")

--- a/workflow/1_context/_buildings.smk
+++ b/workflow/1_context/_buildings.smk
@@ -46,3 +46,16 @@ rule filter_osm_buildings:
             {output.pbf} \
             multipolygons
         """
+
+rule parse_nic_2005_building_sectors:
+    input:
+        script = "workflow/1_context/parse_nic_2005_building_sectors.py",
+        buildings = f"{DATA}/buildings/buildings_assigned_economic_activity.gpkg",
+    output:
+        buildings = f"{DATA}/buildings/buildings_nic2005.geoparquet",
+    shell:
+        """
+        python {input.script} \
+            --buildings {input.buildings} \
+            --output {output.buildings}
+        """

--- a/workflow/1_context/parse_nic_2005_building_sectors.py
+++ b/workflow/1_context/parse_nic_2005_building_sectors.py
@@ -4,6 +4,7 @@ import logging
 import click
 import geopandas
 import pandas
+import tqdm
 
 from jamaica_infrastructure.utils import parse_jic2005
 
@@ -19,11 +20,10 @@ from jamaica_infrastructure.utils import parse_jic2005
 @click.option(
     "--output",
     required=True,
-    type=click.Path(exists=False, dir_okay=False, file_okay=True, writable=True),
+    type=click.Path(exists=False, dir_okay=True, file_okay=True, writable=True),
     help="Path to buildings GeoParquet output",
 )
 def main(buildings, output):
-    buildings_gdf = geopandas.read_file(buildings)
     # List columns to keep - comment out those to drop which are in the base file (as of Mar-2026)
     keep_columns = [
         "osm_id",
@@ -73,12 +73,28 @@ def main(buildings, output):
         # "total_GDP",
         "geometry",
     ]
-    buildings_gdf = buildings_gdf[keep_columns]
 
-    buildings_gdf[["jic2005_two_digit", "jic2005_three_digit"]] = (
-        buildings_gdf.subsector_code.apply(subsector_to_jic2005)
+    buildings_gdf = geopandas.read_file(
+        buildings, columns=keep_columns, use_arrow=True, engine="pyogrio"
     )
-    buildings_gdf.to_parquet(output)
+
+    nrows, _ = buildings_gdf.shape
+    chunksize = 100
+    chunks = int(nrows / chunksize)
+    for chunk in tqdm.trange(chunks):
+        minrow = chunksize * chunk
+        maxrow = chunksize * (chunk + 1)
+        process_chunk(buildings_gdf, f"{output}/{chunk}.parquet", minrow, maxrow)
+
+    process_chunk(buildings_gdf, f"{output}/{chunk + 1}.parquet", maxrow, nrows + 1)
+
+
+def process_chunk(buildings_gdf, output, minrow, maxrow):
+    subset_gdf = buildings_gdf.iloc[minrow:maxrow].copy()
+    subset_gdf[["jic2005_two_digit", "jic2005_three_digit"]] = (
+        subset_gdf.subsector_code.apply(subsector_to_jic2005)
+    )
+    subset_gdf.to_parquet(output)
 
 
 def set_encode(cs):

--- a/workflow/1_context/parse_nic_2005_building_sectors.py
+++ b/workflow/1_context/parse_nic_2005_building_sectors.py
@@ -4,7 +4,6 @@ import logging
 import click
 import geopandas
 import pandas
-import tqdm
 
 from jamaica_infrastructure.utils import parse_jic2005
 
@@ -77,24 +76,10 @@ def main(buildings, output):
     buildings_gdf = geopandas.read_file(
         buildings, columns=keep_columns, use_arrow=True, engine="pyogrio"
     )
-
-    nrows, _ = buildings_gdf.shape
-    chunksize = 100
-    chunks = int(nrows / chunksize)
-    for chunk in tqdm.trange(chunks):
-        minrow = chunksize * chunk
-        maxrow = chunksize * (chunk + 1)
-        process_chunk(buildings_gdf, f"{output}/{chunk}.parquet", minrow, maxrow)
-
-    process_chunk(buildings_gdf, f"{output}/{chunk + 1}.parquet", maxrow, nrows + 1)
-
-
-def process_chunk(buildings_gdf, output, minrow, maxrow):
-    subset_gdf = buildings_gdf.iloc[minrow:maxrow].copy()
-    subset_gdf[["jic2005_two_digit", "jic2005_three_digit"]] = (
-        subset_gdf.subsector_code.apply(subsector_to_jic2005)
+    buildings_gdf[["jic2005_two_digit", "jic2005_three_digit"]] = (
+        buildings_gdf.subsector_code.apply(subsector_to_jic2005)
     )
-    subset_gdf.to_parquet(output)
+    buildings_gdf.to_parquet(output)
 
 
 def set_encode(cs):
@@ -102,7 +87,7 @@ def set_encode(cs):
 
 
 def subsector_to_jic2005(subsector_codes_string):
-    codes = subsector_codes_string.split(",")
+    codes = set(subsector_codes_string.split(","))
     two_or_three_digit = list(
         itertools.chain.from_iterable(parse_jic2005(c) for c in codes)
     )

--- a/workflow/1_context/parse_nic_2005_building_sectors.py
+++ b/workflow/1_context/parse_nic_2005_building_sectors.py
@@ -1,0 +1,104 @@
+import itertools
+import logging
+
+import click
+import geopandas
+import pandas
+
+from jamaica_infrastructure.utils import parse_jic2005
+
+
+@click.command()
+@click.version_option("1.0")
+@click.option(
+    "--buildings",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    help="Path to buildings GeoPackage",
+)
+@click.option(
+    "--output",
+    required=True,
+    type=click.Path(exists=False, dir_okay=False, file_okay=True, writable=True),
+    help="Path to buildings GeoParquet output",
+)
+def main(buildings, output):
+    buildings_gdf = geopandas.read_file(buildings)
+    # List columns to keep - comment out those to drop which are in the base file (as of Mar-2026)
+    keep_columns = [
+        "osm_id",
+        "osm_way_id",
+        "type",
+        "name",
+        "addr_housenumber",
+        "addr_street",
+        "addr_city",
+        "usage",
+        "construction",
+        "other_tags",
+        "sector_code",
+        "subsector_code",
+        "assigned_attribute",
+        "infra_type",
+        "area_sqm",
+        # "to_remove",
+        # "remove",
+        "building_type",
+        "min_damage_cost",
+        "max_damage_cost",
+        "mean_damage_cost",
+        "cost_unit",
+        "residential_type",
+        "residential_population",
+        # "GDP_unit",
+        "ED_ID",
+        "ED",
+        "PARISH",
+        "CONST_NAME",
+        # "A_GDP",
+        # "B_GDP",
+        # "C_GDP",
+        # "D_GDP",
+        # "E_GDP",
+        # "F_GDP",
+        # "G_GDP",
+        # "H_GDP",
+        # "I_GDP",
+        # "J_GDP",
+        # "K_GDP",
+        # "L_GDP",
+        # "M_GDP",
+        # "N_GDP",
+        # "O_GDP",
+        # "total_GDP",
+        "geometry",
+    ]
+    buildings_gdf = buildings_gdf[keep_columns]
+
+    buildings_gdf[["jic2005_two_digit", "jic2005_three_digit"]] = (
+        buildings_gdf.subsector_code.apply(subsector_to_jic2005)
+    )
+    buildings_gdf.to_parquet(output)
+
+
+def set_encode(cs):
+    return ",".join(sorted(list(set(cs))))
+
+
+def subsector_to_jic2005(subsector_codes_string):
+    codes = subsector_codes_string.split(",")
+    two_or_three_digit = list(
+        itertools.chain.from_iterable(parse_jic2005(c) for c in codes)
+    )
+    two_digit = (c[:2] for c in two_or_three_digit)
+    three_digit = (c for c in two_or_three_digit if len(c) == 3)
+    parsed = pandas.Series((set_encode(two_digit), set_encode(three_digit)))
+
+    return parsed
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        format="%(asctime)s %(process)d %(filename)s %(message)s", level=logging.INFO
+    )
+    main()


### PR DESCRIPTION
Parse subsector codes to comma-separate list of two- and three-digit JIC 2005 codes.

Output `processed_data/buildings/buildings_nic2005.geoparquet` with `jic2005_two_digit` and `jic2005_three_digit` columns containing comma-separated string encoding of zero or more codes.